### PR TITLE
Revise empty search result prompt of module list

### DIFF
--- a/odoo/addons/base/views/ir_module_views.xml
+++ b/odoo/addons/base/views/ir_module_views.xml
@@ -208,7 +208,7 @@
             <field name="search_view_id" ref="view_module_filter"/>
             <field name="help" type="html">
               <p class="o_view_nocontent_empty_folder">
-                No website module found!
+                No module found!
               </p><p>
                 You should try other search criteria.
               </p>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
The prompt of empty module list does not make sense.
Current behavior before PR:
It shows 'No website module found!'.
Desired behavior after PR is merged:
Should be 'No module found!'.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
